### PR TITLE
Add note about N6NFI repeater on the main page under the banner

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,9 +22,6 @@
 	      <img src="/images/bannersub-900.jpg" alt="banner">
       </div>
       <br>
-      <div>
-        Weekly net every Monday 8:30PM on <b>N6NFI</b> 145.230 MHz (-) 100Hz
-      </div>
     </header>
 
     <div id="content-wrapper">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,6 @@
       <div class="inner">
 	      <img src="/images/bannersub-900.jpg" alt="banner">
       </div>
-      <br>
     </header>
 
     <div id="content-wrapper">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,6 +21,9 @@
       <div class="inner">
 	      <img src="/images/bannersub-900.jpg" alt="banner">
       </div>
+      <div class="inner">
+        Weekly net every Monday 8:30PM on <b>N6NFI</b> 145.230 MHz (-) 100Hz
+      </div>
     </header>
 
     <div id="content-wrapper">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,11 +21,11 @@
       <div class="inner">
 	      <img src="/images/bannersub-900.jpg" alt="banner">
       </div>
+      <br>
+      <div>
+        Weekly net every Monday 8:30PM on <b>N6NFI</b> 145.230 MHz (-) 100Hz
+      </div>
     </header>
-
-    <div class="inner">
-      Weekly net every Monday 8:30PM on <b>N6NFI</b> 145.230 MHz (-) 100Hz
-    </div>
 
     <div id="content-wrapper">
       <div class="inner clearfix">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,10 +21,11 @@
       <div class="inner">
 	      <img src="/images/bannersub-900.jpg" alt="banner">
       </div>
-      <div class="inner">
-        Weekly net every Monday 8:30PM on <b>N6NFI</b> 145.230 MHz (-) 100Hz
-      </div>
     </header>
+
+    <div class="inner">
+      Weekly net every Monday 8:30PM on <b>N6NFI</b> 145.230 MHz (-) 100Hz
+    </div>
 
     <div id="content-wrapper">
       <div class="inner clearfix">

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div style="text-align: right; font-size: 12px">
-  [Weekly net](/nets.html) every Monday 8:30pm on <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI</a></b> 145.230 MHz (-) 100Hz
+  <a href="/nets.html">Weekly net</a> every Monday 8:30pm on <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI</a></b> 145.230 MHz (-) 100Hz
 </div>
 ---
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div style="text-align: right; font-size: 12px">
-  Weekly net every Monday 8:30PM on <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI</a></b> 145.230 MHz (-) 100Hz
+  Weekly net every Monday 8:30pm on <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI</a></b> 145.230 MHz (-) 100Hz
 </div>
 ---
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: default
 ---
 
 ---
-<div text-align: center font-size: 12px>
+<div style="text-align: centerr; font-size: 12px">
   Weekly net every Monday 8:30PM on <b>N6NFI</b> 145.230 MHz (-) 100Hz
 </div>
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div style="text-align: right; font-size: 12px">
-  Weekly net every Monday 8:30PM on <b>N6NFI</b> 145.230 MHz (-) 100Hz
+  Weekly net every Monday 8:30PM on <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI</a></b> 145.230 MHz (-) 100Hz
 </div>
 ---
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: default
 ---
 
 ---
-<div align="right">
+<div text-align: center font-size: 12px>
   Weekly net every Monday 8:30PM on <b>N6NFI</b> 145.230 MHz (-) 100Hz
 </div>
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div style="text-align: right; font-size: 12px">
-  Weekly net every Monday 8:30pm on <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI</a></b> 145.230 MHz (-) 100Hz
+  [Weekly net](/nets.html) every Monday 8:30pm on <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI</a></b> 145.230 MHz (-) 100Hz
 </div>
 ---
 

--- a/index.md
+++ b/index.md
@@ -3,6 +3,9 @@ layout: default
 ---
 
 ---
+<div align="right">
+  Weekly net every Monday 8:30PM on <b>N6NFI</b> 145.230 MHz (-) 100Hz
+</div>
 
 {% include meeting-short.md %}
 

--- a/index.md
+++ b/index.md
@@ -2,10 +2,10 @@
 layout: default
 ---
 
----
-<div style="text-align: centerr; font-size: 12px">
+<div style="text-align: right; font-size: 12px">
   Weekly net every Monday 8:30PM on <b>N6NFI</b> 145.230 MHz (-) 100Hz
 </div>
+---
 
 {% include meeting-short.md %}
 

--- a/nets.md
+++ b/nets.md
@@ -1,8 +1,6 @@
-# Nets
+# Monday Night Net
 
-## Monday Night Net
-
-### Net Control Schedule
+## Net Control Schedule
 
 Week | Operator
 ---|---
@@ -12,9 +10,9 @@ Week | Operator
 4th Monday  | Rob Fenn, KC6TYD
 5th Monday  | Rob Fenn, KC6TYD
 
-<mark>If you would like to be a Net Control Operator contact Doug at <kg6lwe@paara.org></mark>
+If you would like to be a Net Control Operator contact Doug at <mailto:kg6lwe@paara.org>
 
-### Net Script
+## Net Script
 
 Is this frequency in use? [`Pause`]
 
@@ -59,7 +57,7 @@ Are there any late check-ins? [`pause`]
 
 **Close the Net** - `We wish to thank the owners and trustees of the repeater for use of their system, and everyone for checking in this evening. This is net control [callsign] returning the N6NFI machine to normal use.`
 
-### PAARA Net History
+## PAARA Net History
 
 The PAARA Net has taken many forms over the years. For many years, the club held VHF simplex nets. During the 1970s it begain at 8:15pm on 145.224 MHz—with AM modulation! (As a 1974 PAARAgraphs put it, “…no shoddy FM allowed.”) In February 1975, the net began switching to FM modulation on that same frequency. Some time later, the PAARA Net moved to 147.450 MHz simplex. After the 145.23 machine was activated, the net moved there shortly later to increase the range. On October 1st, 2009, N6NFI permanently enable the PL tone.
 

--- a/nets.md
+++ b/nets.md
@@ -1,5 +1,13 @@
 # Monday Night Net
 
+Monday night nets take place at 8:30pm on the <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI repeater</a></b> (145.230 MHz (-) 100Hz).
+
+There are two [Echolink](https://webapp.echolink.org//) nodes connected to **N6NFI**:
+1. `W6REK-R` (Henry's node)
+2. `KR6DD-R` (Andy's node)
+
+The repeater has a very long squelch tail (3 seconds), and EchoLink will not allow you to transmit until that's complete. This can make it challenging to check into the net, but net control is making efforts to pause for EchoLinkers to give them a chance of checking in.
+
 ## Net Control Schedule
 
 Week | Operator


### PR DESCRIPTION
Rob mentioned we were missing something like this on the main page.

<img width="973" alt="Screenshot 2025-06-01 at 2 47 04 PM" src="https://github.com/user-attachments/assets/44ffa7f2-b49e-4fb8-951a-bc05d28282e8" />

I've also added the details under the "Nets" page, also pointing out that folks can use EchoLink if they're not within RF reach.