### PR TITLE
Add zoom meeting details to the upcoming meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,26 @@ This page acts mainly as a HowTo for other contributors. The old readme is now a
    * topic
    * presenter
    * details
+   * Zoom meeting details
    * example at <https://github.com/PAARA-org/paara-org.github.io/blob/master/meetings/2025/202506.md?plain=1>
 
 2. Upload an image (optional) and render it inline
 3. Modify `_includes/meeting-short.md` to include the same details (this will be rendered on the first page)
    * example at <https://github.com/PAARA-org/paara-org.github.io/blob/41e09eb62eccab82d7b528a0111cd3cf2c46dceb/_includes/meeting-short.md?plain=1>
+
+### How to add Zoom meeting details
+
+Add zoom meeting link and phone dial number to the `_includes/meeting-short.md` as in the example below::
+
+```markdown
+## Next club meeting
+* **Date**: `6 June 2025`
+* **Topic**: `The Legacy of Trans-Pacific Radio`
+* **Presenter**: `Richard Dillman (W6AWO)`
+* **Zoom Meeting**:
+   * <https://us02web.zoom.us/j/81572645379>
+   * <+16699006833,,81572645379#> US (San Jose)
+```
 
 ## What to do after a monthly meeting ends?
 
@@ -40,6 +55,9 @@ This will make the June meeting to be loaded when someone looks at the Monthly M
 * **Date**: `2 May 2025`
 * **Topic**: `The software defined radio, and why it belongs in your shack`
 * **Presenter**: `Carlos Felix, K9OL`
+* **Zoom Meeting**:
+   * <https://us02web.zoom.us/j/81572645379>
+   * <+16699006833,,81572645379#> US (San Jose)
 
 For more information, visit the [meetings page](/meetings.html).
 ```

--- a/_includes/meeting-short.md
+++ b/_includes/meeting-short.md
@@ -2,6 +2,9 @@
 * **Date**: `6 June 2025`
 * **Topic**: `The Legacy of Trans-Pacific Radio`
 * **Presenter**: `Richard Dillman (W6AWO)`
+* **Zoom Meeting**:
+   * <https://us02web.zoom.us/j/81572645379>
+   * <+16699006833,,81572645379#> US (San Jose)
 
 <details>
   <summary><b>Click to see the raffle prizes!</b></summary>

--- a/_includes/meeting-short.md
+++ b/_includes/meeting-short.md
@@ -4,7 +4,7 @@
 * **Presenter**: `Richard Dillman (W6AWO)`
 * **Zoom Meeting**:
    * <https://us02web.zoom.us/j/81572645379>
-   * <+16699006833,,81572645379#> US (San Jose)
+   * +16699006833,,81572645379# US (San Jose)
 
 <details>
   <summary><b>Click to see the raffle prizes!</b></summary>

--- a/_includes/meetings-template.md
+++ b/_includes/meetings-template.md
@@ -19,7 +19,7 @@ The Palo Alto Amateur Radio Association meets on the 1st Friday of the month at 
 
 ![cubberley-600.jpg](/meetings/cubberley-600.jpg)
 
-After the meeting, many members gather for beer, pizza, and eyeball QSO at **Mountain Mike's Pizza**, located at **3918 Middlefield Rd**, in Palo Alto. It's literally next door to Cubberly.
+After the meeting, many members gather for beer, pizza, and eyeball QSO at **Mountain Mike's Pizza**, located at **3918 Middlefield Rd**, in Palo Alto. It's literally next door to Cubberly, in the Charleston Shopping Center.
 
 ## Board Meetings
 

--- a/script/parse-past-meetings.sh
+++ b/script/parse-past-meetings.sh
@@ -21,7 +21,7 @@ The Palo Alto Amateur Radio Association meets on the 1st Friday of the month at 
 
 ![cubberley-600.jpg](/meetings/cubberley-600.jpg)
 
-After the meeting, many members gather for beer, pizza, and eyeball QSO at **Mountain Mike's Pizza**, located at **3918 Middlefield Rd**, in Palo Alto. It's literally next door to Cubberly.
+After the meeting, many members gather for beer, pizza, and eyeball QSO at **Mountain Mike's Pizza**, located at **3918 Middlefield Rd**, in Palo Alto. It's literally next door to Cubberly, in the Charleston Shopping Center.
 
 ## Board Meetings
 


### PR DESCRIPTION
This is only added to the main page, and not to the meetings page. We can change that if needed, but it would be somewhat duplicated information to add it in both places.

I've also made a small addition to the meetings page to describe the meeting place for the Mountain Mike's Pizza.

Last but not least, I've added details on how to add Zoom meeting details into the README.md.