### PR TITLE
Move the "Weekly net every Monday 8:30pm on N6NFI 145.230 MHz (-) 100Hz" info to be rendered just under the banner on smaller screens

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,12 +23,12 @@
       </div>
     </header>
 
-    <div style="text-align: center; font-size: 12px">
-      <a href="/nets.html">Weekly net</a> every Monday 8:30pm on <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI</a></b> 145.230 MHz (-) 100Hz
-    </div>
 
     <div id="content-wrapper">
       <div class="inner clearfix">
+        <div style="text-align: center; font-size: 12px">
+          <a href="/nets.html">Weekly net</a> every Monday 8:30pm on <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI</a></b> 145.230 MHz (-) 100Hz
+        </div>
 
         <aside id="sidebar">
           {% for item in site.data.navigation %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
       </div>
     </header>
 
-    <div style="text-align: right; font-size: 12px">
+    <div style="text-align: center; font-size: 12px">
       <a href="/nets.html">Weekly net</a> every Monday 8:30pm on <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI</a></b> 145.230 MHz (-) 100Hz
     </div>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,7 @@
 
     <div id="content-wrapper">
       <div class="inner clearfix">
-        <div style="text-align: center; font-size: 12px">
+        <div style="text-align: right; font-size: 12px">
           <a href="/nets.html">Weekly net</a> every Monday 8:30pm on <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI</a></b> 145.230 MHz (-) 100Hz
         </div>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,6 +23,10 @@
       </div>
     </header>
 
+    <div style="text-align: right; font-size: 12px">
+      <a href="/nets.html">Weekly net</a> every Monday 8:30pm on <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI</a></b> 145.230 MHz (-) 100Hz
+    </div>
+
     <div id="content-wrapper">
       <div class="inner clearfix">
 
@@ -39,9 +43,6 @@
         </aside>
 
         <section id="main-content">
-          <div style="text-align: right; font-size: 12px">
-          <a href="/nets.html">Weekly net</a> every Monday 8:30pm on <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI</a></b> 145.230 MHz (-) 100Hz
-          </div>
           <hr>
           {{ content }}
         </section>


### PR DESCRIPTION
### Before
![IMG_0207](https://github.com/user-attachments/assets/68592978-0bdf-4710-8498-2f1e0db370e1)

### After
![IMG_0208](https://github.com/user-attachments/assets/f20a6358-6e05-4548-be58-fceafa2b2277)
