### PR TITLE
Add speaker info for the August 2025 meeting

### DIFF
--- a/_includes/meeting-short.md
+++ b/_includes/meeting-short.md
@@ -1,7 +1,7 @@
 ## Next club meeting
 * **Date**: `1 August 2025`
-* **Topic**: `August Monthly Meeting`
-* **Presenter**: `To be announced`
+* **Topic**: `Amateur Radio at Columbia University - History to Present Day`
+* **Presenter**: `Jacob Boxerman (KE2CZX)`
 
 For more information, visit the [meetings page](/meetings.html).
 

--- a/meetings/2025/202508.md
+++ b/meetings/2025/202508.md
@@ -2,10 +2,16 @@
 
 * **Date**: `Aug 1, 2025`
 * **Time**: `07:00 PM Pacific Time`
-* **Topic**: `To be announced`
-* **Presenter**: `To be announced`
+* **Topic**: `Amateur Radio at Columbia University - History to Present Day`
+* **Presenter**: `Jacob Boxerman (KE2CZX)`
 
 ## Details
+
+Jacob Boxerman is a senior at Columbia University studying computer science, with an interest in radio. He restarted the Columbia Space Initiative's High-Altitude Balloons program and have made amateur radio an important part of its mission.
+
+In his presentation he will discuss the Columbia Space Initiative's use of amateur radio in our High-Altitude Balloons mission. The Columbia Space Initiative built a very low budget APRS tracker for use with a launch, and over the past semester it designed micro HF trackers for use on lightweight balloons.
+
+In addition, Jacob will share the history of Columbia's amateur radio club, W2AEE, one of the oldest college clubs in the country.
 
 ## Presentation materials
 


### PR DESCRIPTION
Add all the info from the bug, but change the description from first person to third person.

Fixes: #91