### PR TITLE
Removed Tradewinds Aviation from Sponsors page and moved HRO's ad so that the page is more "balanced"

### DIFF
--- a/sponsors.md
+++ b/sponsors.md
@@ -17,19 +17,17 @@
     <td>&nbsp;</td>
     <td><img src="/images/sponsors/rescuetape-300.jpg" width="300" height="170" border="0" alt="sponsor page" /></td>
     <td>&nbsp;</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>&nbsp;</td>
-    <td>&nbsp;</td>
-    <td>&nbsp;</td>
-    <td>&nbsp;</td>
-  </tr>
-  <tr>
-    <td>&nbsp;</td>
-    <td rowspan="2" valign="top"><img src="/images/sponsors/tradewinds.jpg" width="301" height="398" alt="sponsor page" /></td>
-    <td>&nbsp;</td>
     <td><img src="/images/sponsors/HRO-300.jpg" width="300" height="96" alt="sponsor page" /></td>
+  </tr>
+  <tr>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+  </tr>
+  <tr>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
   </tr>
   <tr>
     <td>&nbsp;</td>


### PR DESCRIPTION
Removed Tradewinds Aviation from Sponsors page and moved HRO next to Rescue Tape's ad so that all 4 ads are now better balanced on the page.
Resolves #94