### PR TITLE
Changed Vic Black's Life Membership info on Membership page to SK

### DIFF
--- a/membership.md
+++ b/membership.md
@@ -17,7 +17,7 @@ If you want to access the most up-to-date member list, please click [here](https
 |------|-----------|------------|--------------|------------|
 | Andrew Korsak | [KR6DD](https://www.qrz.com/db/KR6DD){:target="_blank"} | -- | [pdf](/membership/Andy_Korsak_proclamation.pdf) | 2024 |
 | Jim Rice | [K6AK](https://www.qrz.com/db/K6AK){:target="_blank"} | -- | [pdf](/membership/Jim_Rice_proclamation2.pdf) | 2022 |
-| Vic Black | [AB6SO](https://www.qrz.com/db/AB6SO){:target="_blank"} | SK | -- |2021 |
+| Vic Black | [AB6SO](https://www.qrz.com/db/AB6SO){:target="_blank"} | SK |  [pdf](/membership/Vic_Black_certificate.pdf)  |2021 |
 | Gerry Tucker | [N6NV](https://www.qrz.com/db/N6NV){:target="_blank"} | -- | [pdf](/membership/Gerry_proclamantion_3.pdf) | 2019 |
 | Steve Stuntz | [K6FS](https://www.qrz.com/db/K6FS){:target="_blank"} | SK | -- |2007 |
 | Joe Gomes | [KB6HDC](https://www.qrz.com/db/KB6HDC){:target="_blank"} | SK | -- | 2004-05 |

--- a/membership.md
+++ b/membership.md
@@ -17,8 +17,8 @@ If you want to access the most up-to-date member list, please click [here](https
 |------|-----------|------------|--------------|------------|
 | Andrew Korsak | [KR6DD](https://www.qrz.com/db/KR6DD){:target="_blank"} | -- | [pdf](/membership/Andy_Korsak_proclamation.pdf) | 2024 |
 | Jim Rice | [K6AK](https://www.qrz.com/db/K6AK){:target="_blank"} | -- | [pdf](/membership/Jim_Rice_proclamation2.pdf) | 2022 |
-| Gerry Tucker | [N6NV](https://www.qrz.com/db/N6NV){:target="_blank"} | -- | [pdf](/membership/Gerry_proclamantion_3.pdf) | 2019 |
 | Vic Black | [AB6SO](https://www.qrz.com/db/AB6SO){:target="_blank"} | SK | -- |2021 |
+| Gerry Tucker | [N6NV](https://www.qrz.com/db/N6NV){:target="_blank"} | -- | [pdf](/membership/Gerry_proclamantion_3.pdf) | 2019 |
 | Steve Stuntz | [K6FS](https://www.qrz.com/db/K6FS){:target="_blank"} | SK | -- |2007 |
 | Joe Gomes | [KB6HDC](https://www.qrz.com/db/KB6HDC){:target="_blank"} | SK | -- | 2004-05 |
 | Leslie Vickery | [W6AKR](https://www.qrz.com/db/W6AKR){:target="_blank"} | SK | -- | -- |

--- a/membership.md
+++ b/membership.md
@@ -17,8 +17,8 @@ If you want to access the most up-to-date member list, please click [here](https
 |------|-----------|------------|--------------|------------|
 | Andrew Korsak | [KR6DD](https://www.qrz.com/db/KR6DD){:target="_blank"} | -- | [pdf](/membership/Andy_Korsak_proclamation.pdf) | 2024 |
 | Jim Rice | [K6AK](https://www.qrz.com/db/K6AK){:target="_blank"} | -- | [pdf](/membership/Jim_Rice_proclamation2.pdf) | 2022 |
-| Vic Black | [AB6SO](https://www.qrz.com/db/AB6SO){:target="_blank"} | -- | [pdf](/membership/Vic_Black_certificate.pdf) | 2021 |
 | Gerry Tucker | [N6NV](https://www.qrz.com/db/N6NV){:target="_blank"} | -- | [pdf](/membership/Gerry_proclamantion_3.pdf) | 2019 |
+| Vic Black | [AB6SO](https://www.qrz.com/db/AB6SO){:target="_blank"} | SK | -- |2021 |
 | Steve Stuntz | [K6FS](https://www.qrz.com/db/K6FS){:target="_blank"} | SK | -- |2007 |
 | Joe Gomes | [KB6HDC](https://www.qrz.com/db/KB6HDC){:target="_blank"} | SK | -- | 2004-05 |
 | Leslie Vickery | [W6AKR](https://www.qrz.com/db/W6AKR){:target="_blank"} | SK | -- | -- |

--- a/membership.md
+++ b/membership.md
@@ -17,7 +17,7 @@ If you want to access the most up-to-date member list, please click [here](https
 |------|-----------|------------|--------------|------------|
 | Andrew Korsak | [KR6DD](https://www.qrz.com/db/KR6DD){:target="_blank"} | -- | [pdf](/membership/Andy_Korsak_proclamation.pdf) | 2024 |
 | Jim Rice | [K6AK](https://www.qrz.com/db/K6AK){:target="_blank"} | -- | [pdf](/membership/Jim_Rice_proclamation2.pdf) | 2022 |
-| Vic Black | [AB6SO](https://www.qrz.com/db/AB6SO){:target="_blank"} | SK |  [pdf](/membership/Vic_Black_certificate.pdf)  |2021 |
+| Vic Black | [AB6SO](https://www.qrz.com/db/AB6SO){:target="_blank"} | SK | [pdf](/membership/Vic_Black_certificate.pdf)  | 2021 |
 | Gerry Tucker | [N6NV](https://www.qrz.com/db/N6NV){:target="_blank"} | -- | [pdf](/membership/Gerry_proclamantion_3.pdf) | 2019 |
 | Steve Stuntz | [K6FS](https://www.qrz.com/db/K6FS){:target="_blank"} | SK | -- |2007 |
 | Joe Gomes | [KB6HDC](https://www.qrz.com/db/KB6HDC){:target="_blank"} | SK | -- | 2004-05 |


### PR DESCRIPTION
Moved Vic Black's name to the SK grouping in the Special Life Membership section of the Membership page. Removed link to PDF also.
Resolves #95 