### PR TITLE
Fix the September meeting page title

### DIFF
--- a/meetings/2025/202509.md
+++ b/meetings/2025/202509.md
@@ -1,4 +1,4 @@
-# __MONTH__ Monthly Meeting
+# September Monthly Meeting
 
 * **Date**: `Sep 5, 2025`
 * **Time**: `07:00 PM Pacific Time`


### PR DESCRIPTION
Right now the title says MONTH monthly meeting instead of September monthly meeting.