### PR TITLE
Add table of contents to every page that has more than just a couple of headings

### DIFF
--- a/aboutus.md
+++ b/aboutus.md
@@ -1,8 +1,10 @@
 # About us
 
+---
 **Table of Contents**
 * Table of Contents
 {:toc}
+---
 
 [Club Meeting Information & Location](/meetings.md)
 

--- a/fieldday/2025.md
+++ b/fieldday/2025.md
@@ -1,8 +1,10 @@
 # Field Day 2025
 
+---
 **Table of Contents**
 * Table of Contents
 {:toc}
+---
 
 Field Day was a success; see you all next year!
 

--- a/loan.md
+++ b/loan.md
@@ -1,8 +1,10 @@
 # Radio Loan Program
 
+---
 **Table of Contents**
 * Table of Contents
 {:toc}
+---
 
 Do you have a new or recent license upgrade?  Are you interested in DX, SSB, international contesting? Are you concerned about the “thousand-dollar upgrade”?
 

--- a/meetings/2025/202512.md
+++ b/meetings/2025/202512.md
@@ -17,9 +17,11 @@ Eric will also take your questions and comments, including your ideas for new pr
 
 {% include raffle/202512.md %}
 
+---
 **Table of Contents**
 * Table of Contents
 {:toc}
+---
 
 {% include meetings-template.md %}
 

--- a/membership.md
+++ b/membership.md
@@ -1,8 +1,10 @@
 # Membership Information and Badges
 
+---
 **Table of Contents**
 * Table of Contents
 {:toc}
+---
 
 ## Membership History
 

--- a/nets.md
+++ b/nets.md
@@ -1,8 +1,10 @@
 # Monday Night Net
 
+---
 **Table of Contents**
 * Table of Contents
 {:toc}
+---
 
 Monday night nets take place at 8:30pm on the <b><a href="https://www.fars.k6ya.org/repeaters/n6nfi" target="_blank">N6NFI repeater</a></b> (145.230 MHz (-) 100Hz).
 

--- a/newham.md
+++ b/newham.md
@@ -4,11 +4,13 @@ layout: default
 
 # Welcome, New Hams
 
-We're looking forward to seeing you at our next meeting or event!
-
+---
 **Table of Contents**
 * Table of Contents
 {:toc}
+---
+
+We're looking forward to seeing you at our next meeting or event!
 
 ## Free Membership
 

--- a/ontheair.md
+++ b/ontheair.md
@@ -1,8 +1,10 @@
 # POTA / SOTA
 
+---
 **Table of Contents**
 * Table of Contents
 {:toc}
+---
 
 [POTA](http://pota.app){:target="_blank"} (Parks on the Air) and [SOTA](https://www.sota.org.uk/){:target="_blank"} (Summits on the Air) are just two programs encouraging portable operations in either US National/State Parks/Historic trails, or on Summits.
 

--- a/photos.md
+++ b/photos.md
@@ -1,8 +1,10 @@
 # Photos
 
+---
 **Table of Contents**
 * Table of Contents
 {:toc}
+---
 
 ## Pacificon 2025
 

--- a/resources.md
+++ b/resources.md
@@ -1,8 +1,10 @@
 # Resources
 
+---
 **Table of Contents**
 * Table of Contents
 {:toc}
+---
 
 ## Local resources
 


### PR DESCRIPTION
To make it easier to separate the TOC from the rest of the page, I've added horizontal lines before and after the TOC block.

Preview at https://kn6yuh.github.io/index.html