### PR TITLE
Changing the Paypal cart ID for membership renewal

### DIFF
--- a/membership/pay.md
+++ b/membership/pay.md
@@ -25,9 +25,9 @@ Zelle transfers are instant, and they do not charge any fees to the club.
 2. **Call Sign** (or `None`)
 3. **Individual member call sign** (for family membership)
 
-<paypal-add-to-cart-button data-id="JWDYVV8LAQR4E"></paypal-add-to-cart-button>
+<paypal-add-to-cart-button data-id="J32CYFN3AAFDL"></paypal-add-to-cart-button>
 <script>
-  cartPaypal.AddToCart({ id: "JWDYVV8LAQR4E" })
+  cartPaypal.AddToCart({ id: "J32CYFN3AAFDL" })
 </script>
 
 **NOTE:** Once you've added your name and call sign to the order details, please click on the cart below to finalize the payment.


### PR DESCRIPTION
The old cart wasn't working anymore due to some changes on the Paypal side. The error we were getting is:

```json
{
    "status": 400,
    "error": true,
    "name": "INVALID_REQUEST",
    "message": "Request is not well-formed, syntactically incorrect, or violates schema.",
    "debug_id": "f464522419103",
    "details": [
        {
            "field": "/item/memos/0/label",
            "value": "Regular Member: Please enter your full name, and callsign (or \"None\"), each on a separate line. Family member, enter your full name and the regular member's callsign.",
            "location": "body",
            "issue": "INVALID_STRING_LENGTH",
            "description": "the value of a field is either too short or too long."
        }
    ],
```

@Ric-Hulett has shortened the cart description to only contain:  `Regular Member: Please enter your name, and callsign. Fam member, name plus regular member call.` which seems to have done the trick!

Preview at https://kn6yuh.github.io/membership/pay.html
