### PR TITLE
Add new Paypal form that allows donors to specify not just their name, but also a short message

### DIFF
--- a/donate.md
+++ b/donate.md
@@ -2,33 +2,17 @@
 
 Your generous donation will help PAARA offset expenses for Field Day, Days in the Park, Field Trips, the Annual Electronics Flea Market, the Holiday Dream To Reality Raffle, and other activities.
 
-Please use the form below. You will be able to donate via a credit card or directly from your PayPal account.   We also welcome equipment donations.   Please contact the club president for more information.
+Please use the form below. You will be able to donate via a credit card or directly from your PayPal account. We also welcome equipment donations. Please contact the club president for more information.
 
+<script src="https://www.paypal.com/sdk/js?client-id=BAApzfMz4eu7PvkRHlc2cYaZFUEw2bzgXKAnhftc43l5Y2D5Cb_PiJNDFhyBo7DeetNcRkws79Es0NqDx4&components=hosted-buttons&enable-funding=venmo&currency=USD">
+</script>
 
-<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-<input type="hidden" name="cmd" value="_s-xclick">
-<input type="hidden" name="hosted_button_id" value="LCRCAB44UNBZN">
-
-<table width="300" align="center">
-
-<tr><td><div align="center">
-  <input type="hidden" name="on1" value="Your Name">
-  <span class="tahoma-14-boldred">Your </span><span class="tahoma-14-bluebold">FULL NAME</span></div></td></tr><tr><td><div align="center">
-  <input type="text" name="os1" maxlength="200">
-  </div></td></tr>
-  <tr><td><div align="center">
-  <input type="hidden" name="on2" value="Your Callsign">
-  <span class="tahoma-14-boldred">Your Callsign</span></div></td></tr><tr><td><div align="center">
-  <input type="text" name="os2" maxlength="200">
-  </div></td></tr>
-</table><br/>
-
- <div align="center">
-  <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-  <img alt="pixel" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1"></div>
- </form>
-<br />
+<div id="paypal-container-ZUPMU4FV2E9EW"></div>
+<script>
+  paypal.HostedButtons({
+    hostedButtonId: "ZUPMU4FV2E9EW",
+  }).render("#paypal-container-ZUPMU4FV2E9EW")
+</script>
 
 **NOTE**: PAARA is a `501(c)(7)` non-profit corporation. 
-
 


### PR DESCRIPTION
This was the last form that used the old style forms from Paypal. Ric helped generate the link.