### PR TITLE
Update Field Day 2026 page: phone station captain, park rules, antenna party dates

### DIFF
--- a/fieldday/2026.md
+++ b/fieldday/2026.md
@@ -21,7 +21,7 @@ PAARA has a 2026 edition Field Day T-shirt available for purchase. Check out the
 
 We compete in Class 3A, running 3 primary HF stations, including a dedicated digital mode station running FT8 and FT4 on 20 Meters. [**Marty** W6NEV](https://www.qrz.com/db/W6NEV){:target="_blank"} captains this station.
 
-In addition, we operate 2 other HF stations, running amplifiers to increase transmit power up to the 500-watt limit, captained by [**Ric** N6AJS](https://www.qrz.com/db/N6AJS){:target="_blank"} primarily on our CW station and [**Harry** K4YR](https://www.qrz.com/db/K4YR){:target="_blank"}, running mostly phone.
+In addition, we operate 2 other HF stations, running amplifiers to increase transmit power up to the 500-watt limit. [**Ric** N6AJS](https://www.qrz.com/db/N6AJS){:target="_blank"} captains our CW station. Harry, K4YR is no longer living in the area, so we are looking for a new Station Captain for our phone station — someone with HF Phone operation and station setup experience to run this station over the course of the event, including set up, teardown and pack up, and most importantly keeping the station staffed and making contacts for the entire 24 hours of the event.
 
 We always have a BIG signal from our excellent location, featuring sloping terrain angled down to the saltwater marsh at the edge of the bay giving us the "saltwater amp" effect, increasing our signals even more.
 
@@ -32,17 +32,18 @@ As always, we have our excellent GOTA station to give interested visitors who ha
 Rounding out the mix are UHF/VHF/satellite operations, captained by [**Justin** AI6YM](https://www.qrz.com/db/AI6YM){:target="_blank"}, featuring his impressive home-brewed azimuth/elevation rotor system for the satellite antenna array he has designed and built.
 
 ### Antenna Parties
-Advance preparation for Field Day will include several (likely 4) antenna work parties at [**Doug** KG6LWE](https://www.qrz.com/db/KG6LWE){:target="_blank"}’s San Martin QTH, and Network Day to connect all the radios and logging computers on a couple of tables in Marty’s garage to work out any connection or communication issues before getting to the park.
+Advance preparation for Field Day will include 4 scheduled antenna work parties at [**Doug** KG6LWE](https://www.qrz.com/db/KG6LWE){:target="_blank"}’s San Martin QTH, and Network Day to connect all the radios and logging computers on a couple of tables in Marty’s garage to work out any connection or communication issues before getting to the park.
 
-We have always enjoyed these “work parties” and have found them to be good team-building opportunities, as well as good practice in assembling the antennas and getting them up in the air. If you’re interested in coming out for a couple of fun days in the sun with the team, please let Doug know. Planning for these is already underway.
+We have always enjoyed these “work parties” and have found them to be good team-building opportunities, as well as good practice in assembling the antennas and getting them up in the air. If you’re interested in coming out for a couple of fun days in the sun with the team, please let Doug know.
 
-#### Antenna Party #1 
+The 4 scheduled antenna work parties are:
 
-#### Antenna Party #2 
+* May 16
+* May 23
+* May 30
+* June 20
 
-#### Antenna party #3
-
-#### Antenna party #4
+Others may be scheduled on an as-needed basis.
 
 ### Installation
 
@@ -74,7 +75,6 @@ To protect our long lasting relationship with the City of Menlo Park and the par
 * Litter and trash are to be disposed of properly 
 * Fire, smoking, alcohol, or weapons of any kind are prohibited
 * Drones and other unmanned aircraft systems are not allowed
-* Tents or other enclosed structures are not allowed
 
 #### Exemptions for Field Day 
 


### PR DESCRIPTION
## Summary

Three updates to the Field Day 2026 page based on feedback:

- **Phone station captain**: Harry K4YR has moved out of state. Replaced his listing with a call for a new Station Captain — someone with HF Phone operation and station setup experience to run the station for the full 24 hours of the event, including setup, teardown, and keeping it staffed.
- **Park rules**: Dropped the "Tents or other enclosed structures are not allowed" line. It's not in the City's published rules, the City staff working the event last year were unaware of it, and it directly conflicts with our planned use of fold-up shelters.
- **Antenna parties**: Replaced the four empty subsection placeholders with the actual scheduled dates — May 16, 23, 30, and June 20 — with a note that others may be scheduled as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)