### PR TITLE
Add local preview setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Gemfile.lock
 .jekyll-cache
 .DS_Store
 .claude/
+vendor/
+.bundle/

--- a/PREVIEW.md
+++ b/PREVIEW.md
@@ -1,0 +1,19 @@
+# Previewing the site locally
+
+## Prerequisites
+
+The following packages are required (correct for Ubuntu 24.04.4 — your distro may differ):
+
+```sh
+sudo apt install build-essential ruby3.2-dev
+```
+
+`ruby3.2-dev` pulls in `ruby3.2`. `build-essential` is needed to compile native gem extensions.
+
+## Usage
+
+```sh
+./preview.sh
+```
+
+Open http://localhost:4000. Jekyll auto-regenerates on file changes — just save and refresh.

--- a/preview.sh
+++ b/preview.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd "$(dirname "$0")"
+
+if ! command -v gem &>/dev/null; then
+    echo "Error: 'gem' not found. Install Ruby first." >&2
+    exit 1
+fi
+
+root="$(pwd)"
+export GEM_HOME="$root/vendor/gems"
+export GEM_PATH="$root/vendor/gems"
+export PATH="$root/vendor/gems/bin:$PATH"
+
+if ! command -v bundle &>/dev/null; then
+    echo "Installing bundler..."
+    gem install bundler
+fi
+
+bundle config set --local path vendor/bundle
+
+if ! bundle check >/dev/null 2>&1; then
+    echo "Installing gems..."
+    bundle install
+fi
+
+exec bundle exec jekyll serve


### PR DESCRIPTION
- Adds `preview.sh` to set up and serve the site locally with all gems installed into `vendor/` (no sudo, no writes outside the project)
- Adds `PREVIEW.md` documenting prerequisites and usage
- Updates `.gitignore` to exclude `vendor/`, `.bundle/`
