### PR TITLE
Add setup guide structure and preview workflow

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,6 +8,8 @@
   link: /calendar.html
 - name: Events
   link: /events.html
+- name: Setup Guides
+  link: /events/setup-guides/index.html
 - name: Field Day
   link: /fieldday.html
 - name: Meetings

--- a/events/setup-guides/equipment/index.md
+++ b/events/setup-guides/equipment/index.md
@@ -5,10 +5,10 @@ These guides document reusable setup and teardown procedures for individual piec
 ## Guides
 
 * [KLM KT36 yagi antenna](/events/setup-guides/equipment/klm-kt36.html)
+* [KLM KT34A yagi antenna](/events/setup-guides/equipment/klm-kt34.html)
 
 ## Planned Guides
 
 * AB-621 tower
-* 4-element KLM KT-34 yagi antenna
 * Tower trailer
 * 40 m monoband 4-element yagi

--- a/events/setup-guides/equipment/index.md
+++ b/events/setup-guides/equipment/index.md
@@ -1,0 +1,14 @@
+# Equipment Setup Guides
+
+These guides document reusable setup and teardown procedures for individual pieces of PAARA equipment. Event setup guides should link here when a station uses one of these items.
+
+## Guides
+
+* [KLM KT36 yagi antenna](/events/setup-guides/equipment/klm-kt36.html)
+
+## Planned Guides
+
+* AB-621 tower
+* 4-element KLM KT-34 yagi antenna
+* Tower trailer
+* 40 m monoband 4-element yagi

--- a/events/setup-guides/equipment/index.md
+++ b/events/setup-guides/equipment/index.md
@@ -2,6 +2,12 @@
 
 These guides document reusable setup and teardown procedures for individual pieces of PAARA equipment. Event setup guides should link here when a station uses one of these items.
 
+---
+**Table of Contents**
+* Table of Contents
+{:toc}
+---
+
 ## Guides
 
 * [KLM KT36 yagi antenna](/events/setup-guides/equipment/klm-kt36.html)

--- a/events/setup-guides/equipment/klm-kt34.md
+++ b/events/setup-guides/equipment/klm-kt34.md
@@ -4,6 +4,12 @@ This guide documents setup and teardown for the club's 4-element KLM KT-34A HF y
 
 The KT34 packs most of the punch of its big brother, but with significantly easier setup and teardown. It has two driven elements, driven 180 degrees out of phase with each other, one director and one reflector. It has a 3KW rated 4:1 balun serving the 50W match. Phasing on the driven elements is achieved with straps shorting the left side of one driven element to the right side of the other, and vice-versa.
 
+---
+**Table of Contents**
+* Table of Contents
+{:toc}
+---
+
 
 ## Overview
 

--- a/events/setup-guides/equipment/klm-kt34.md
+++ b/events/setup-guides/equipment/klm-kt34.md
@@ -1,0 +1,110 @@
+# KLM KT34A Setup Guide
+
+This guide documents setup and teardown for the club's 4-element KLM KT-34A HF yagi antenna. This antenna is the "little brother" of the 6-element KLM KT36A.
+
+The KT34 packs most of the punch of its big brother, but with significantly easier setup and teardown. It has two driven elements, driven 180 degrees out of phase with each other, one director and one reflector. It has a 3KW rated 4:1 balun serving the 50W match. Phasing on the driven elements is achieved with straps shorting the left side of one driven element to the right side of the other, and vice-versa.
+
+
+## Overview
+
+This page covers how to put together our club's KLM KT34. It is specific to our club, in that we have a set of markings on the antenna that help us repeat the process.
+
+This guide does not cover the full process of building the antenna for the first time from the parts that come out of the box(es).
+
+
+## Tools Required
+
+- 9/16 socket, for mast and mounting plate bolts
+- 7/16 socket, for the truss system
+- 1/2 inch socket, for the mounting plate bolts
+- 3/8 socket, for the phasing strap mounts
+- 11/32 socket, for the balun mount
+- 5/16 socket, for hose clamps (a flathead screwdriver would work but be much less pleasant)
+
+NOTE: Maybe we should consider standardizing these a bit better. We could easily optimize out two of these required socket sizes (11/32 and 1/2)
+
+## Markings and Modifications
+
+There are several markings on the antenna which tell us how to disassemble/reassemble the antenna:
+
+- There is a sticker with an arrow on the front of the boom, pointing towards the side of the antenna with the directors
+- Each element has black and red electrical tape on the left and right sides of the element (respectively)
+- There are numbers etched into each element, indicating how far back from the director they should be.
+- There is also paint indicating where the truss pieces mount to the boom
+
+## Unpacking
+
+The antenna is usually stored on the roof of the PAARA box trailer. It's stored as:
+
+- 4 elements
+- Boom bundle:
+	- Truss rope
+	- Mast mounting plate
+
+The "boom bundle" is taped together with electrical tape.
+
+This antenna has only one boom section, and it has no mast adapter. Instead, on the bottom of the mounting plate, there are U-Bolts which go directly onto a mast stub of some kind.
+
+## Assembly
+
+The KT34 comes together relatively quickly. This is because it has fewer parts than its big brother.
+
+1. Put the single piece boom on a few sawhorses
+2. Line up the elements in the right order and put them in the right place. There are etched numbers in each element. 1 is the director and should be closest to the direction arrow, 2 is the front driven element, etc. There is spray paint indicating where they should go, but refer to the data sheet (TODO: Link) which has measurements in case of ambiguity.
+3. Attach the elements with the hose clamps. Unfortunately, the drive point of the hose clamps are not all facing the same direction. Do not use the hose clam to determine the left/right alignment of the elements. Additionally, the linear loading sections do not all face the right way. Trust the red/black electrical tape! Use a 5/16" socket to tighten the hose clamps. 
+
+IMPORTANT: it is very easy to damage hose clamps by over-tightening. Especially if using power tools, be extra careful when tightening.
+
+4. Place sawhorses under a couple of elements (ideally two on each side) to keep the antenna from rolling
+5. Attach the phasing lines. The phasing lines go across the two driven elements, from the left side on the front element to the right on the rear, and vice-versa. There is a 3D-printed spacer (de KK6ISP) which mostly keeps them from shorting to each other. The bolts are 3/8".
+
+IMPORTANT: The phasing straps connect to the outside set of bolts on each driven element, not the inside (TODO: Photo).
+
+IMPORTANT: Make sure the phasings straps are not shorting (touching) anything other than the bolts they are connected to. Tape them in place.
+
+6. Attach the Balun. The Balun has a set of U-Bolts for mounting. It should point with the coax facing towards the mast. The balun wires have ring terminals which connect to the outside set of bolts on the matching element of the forward driven eleent. These bolts are 11/32
+
+7. Loosen the bolts attaching the mounting plate to the boom so that it can rotate not quite freely. This will make it easier to catch the mount when it's time.
+
+8. Level the elements. Choose one (usually the front) to act as the reference, and, keeping one level on the reference, use a second level to check that all the elements are level to each other.
+
+
+## Mounting
+
+For instructions on preparing a tower to accept an antenna, see one of the tower setup guides.
+
+The KT34A slides onto a mast with a set of U-bolts, not to be confused with U-boats, which are German submarines from the 1940s.
+
+First, fully loosen the U-bolts. There are eight nuts, two on each of four U-bolts. They need to be loosened almost all the way for a normal mast to fit through.
+
+Make sure that when you slide the mast through, the saddles are on the opposite side of the mast from the curved part of the U-bolt. Push the antenna down a bit, then attach the truss mount above the antenna on the mast. Tighten down the truss mount first, and then push the antenna down the mast until the truss is taut. You don't want slack, but you also don't want the truss cable to become a piano string.
+
+IMPORTANT: If you are going to rotate the antenna as part of hoisting, make sure the mast plate is loosened so it doesn't stay sideways.
+
+Tie a string to one element on each side of the boom, to keep the antenna parallel to the ground while hoisting until the bolts are tightened, if you will rotate the antenna.
+
+Before hoisting the antenna, make sure the coax is connected. Tape the coax to the boom to reduce stress on it and keep it from bouncing around and interfering with anything.
+
+
+## Teardown and Packing
+
+Teardown is essentially the reverse of assembly.
+
+1. First, follow any tower-specific lowering instructions. This will be a bit different for different kinds of towers. In any case, remove the feedline before taking the antenna off of the tower
+
+2. Place the antenna on a set of sawhorses. Put at least one sawhorse under an element on each side of the antenna to keep it from rolling.
+
+3. Remove the truss, balun, and phasing straps before pulling elements or hardware apart.
+
+4. Remove elements by loosening hose clamps. The hose clamps on the two elements on the end do not need to be fully opened. The two middle elements do.
+
+5. Tape the phasing straps and mounting plate to the boom, as well as the truss rope.
+
+We typically pack the elements on top of the box trailer. The elements get wired down to the ladder rack in pairs, and the boom gets wired down on its own.
+
+
+## Common Gotchas and FAQs
+
+- The Balun mounts near the driven element which has the extra cross-component. The Balun leads mount to the bolts on the cross-compoonent. This is the front driven element. Photo:
+- The phasing lines mount to the outside set of bolts on the two driven elements.
+- The truss wants enough tension to hold shape, but not so much that it bends the boom or distorts the driven elements.

--- a/events/setup-guides/equipment/klm-kt36.md
+++ b/events/setup-guides/equipment/klm-kt36.md
@@ -1,0 +1,56 @@
+# KLM KT36 Setup Guide
+
+This guide documents setup and teardown for the club's 6-element KLM KT-36 HF yagi antenna, affectionately known as the "tri bander".
+
+The KT-36 is an interesting antenna: a multi-band HF Yagi with 9-10 dB of gain across the three bands. It has served us well at field day.
+
+## Overview
+
+This page covers how to put together our club's KLM KT36. It is specific to our club, in that we have a set of markings on the antenna that help us repeat the process.
+
+This guide does not cover the full process of building the antenna for the first time from the parts that come out of the box(es).
+
+
+## Tools Required
+
+- 9/16 socket, for mast and mounting plate bolts
+- 7/16 socket, for bolts holding the pieces of the boom together and the truss system.
+- 3/8 socket, for balun mounts and phasing strap mounts
+- 5/16 socket, for hose clamps (a flathead screwdriver would work but be much less pleasant)
+
+## Markings and Modifications
+
+There are several markings on the antenna which tell us how to disassemble/reassemble the antenna:
+
+- There are stripes of green electrical tape just to the outside of the bolts where we take the boom apart. We only split the boom in half.
+- There is a sticker with an arrow on the front of the boom, pointing towards the side of the antenna with the directors
+- Each element has black and red electrical tape on the left and right sides of the element (respectively)
+- There is color coded spray paint indicating which elements go where. There are actually several layers of spray paint on the antenna. The newest set is orange, blue, yellow/blue, and purple/yellow.
+- There is also paint indicating where the truss pieces mount to the boom
+
+## Unpacking
+
+Add the parts inventory, inspection steps, required tools, crew size, and safety checks here.
+
+## Assembly
+
+Add the boom, element, matching network, truss, and hardware assembly steps here.
+
+## Mounting
+
+Add mast, rotator, tower, feedline, and strain-relief steps here.
+
+## Testing
+
+Add continuity, SWR, rotator, and on-air test steps here.
+
+## Teardown
+
+Add the teardown order, packing notes, and post-event inspection steps here.
+
+## Common Gotchas and FAQs
+
+- The Balun mounts near the driven element which has the extra cross-component. The Balun leads mount to the bolts on the cross-compoonent. This is the rear driven element. Photo:
+- The phasing lines mount to the outside set of bolts on the two driven elements.
+- When you rotate the mast ahead of mounting, rotate it so that the truss stays above the elements, and the end of the mast which will go into the tower is slightly below the elements. This is to the left, facing towards the front of the antenna.
+

--- a/events/setup-guides/equipment/klm-kt36.md
+++ b/events/setup-guides/equipment/klm-kt36.md
@@ -10,10 +10,12 @@ This page covers how to put together our club's KLM KT36. It is specific to our 
 
 This guide does not cover the full process of building the antenna for the first time from the parts that come out of the box(es).
 
+The KT36 is a beast. It has two driven elements, driven 180 degrees out of phase with each other, three directors and one reflector. It has a 3KW rated 4:1 balun serving the 50W match. Phasing on the driven elements is achieved with straps shorting the left side of one driven element to the right side of the other, and vice-versa.
+
 
 ## Tools Required
 
-- 9/16 socket, for mast and mounting plate bolts
+- 9/16 socket, for mast and mounting plate bolts (TODO: are the mast u-bolts 9/16 or 1/2?)
 - 7/16 socket, for bolts holding the pieces of the boom together and the truss system.
 - 3/8 socket, for balun mounts and phasing strap mounts
 - 5/16 socket, for hose clamps (a flathead screwdriver would work but be much less pleasant)
@@ -27,6 +29,7 @@ There are several markings on the antenna which tell us how to disassemble/reass
 - Each element has black and red electrical tape on the left and right sides of the element (respectively)
 - There is color coded spray paint indicating which elements go where. There are actually several layers of spray paint on the antenna. The newest set is orange, blue, yellow/blue, and purple/yellow.
 - There is also paint indicating where the truss pieces mount to the boom
+- Each element (will have) has numbers etched into them, indicating how far from the front director they should be installed.
 
 ## Unpacking
 
@@ -43,19 +46,70 @@ The "boom bundle" is taped together with electrical tape.
 
 ## Assembly
 
-Add the boom, element, matching network, truss, and hardware assembly steps here.
+The KT36 assembly process is relatively straightforward. It's similar to the KT34, but with a couple extra elements.
+
+One interesting note is that the second element from the front is much shorter and stubbier than the others. It is only active on the 10m band, and is not linearly loaded like the others.
+
+The biggest mechanical difference between assembling the KT34 and KT36 is the mounting system. The KT36 has a short mast that stays with it. This means that it needs an adapter to attach to a tower with a mast.
+
+1. After unpacking, place the two pieces of the boom on sawhorses. They attach with two 7/16" bolts. There is a sticker with an arrow on the forward boom section. 
+2. Line up the elements in the right order and put them in the right place. There are etched numbers in each element. 1 is the director and should be closest to the direction arrow, 2 is the short 10m director, 3 is the front driven element, etc. There is spray paint indicating where they should go, but refer to the data sheet (TODO: Link) which has measurements in case of ambiguity. (TODO: add etched numbers to the elements next time we disassemble)
+3. Attach the elements with the hose clamps. Unfortunately, the drive point of the hose clamps are not all facing the same direction. Do not use the hose clam to determine the left/right alignment of the elements. Additionally, the linear loading sections do not all face the right way. Trust the red/black electrical tape! Use a 5/16" socket to tighten the hose clamps. 
+
+IMPORTANT: it is very easy to damage hose clamps by over-tightening. Especially if using power tools, be extra careful when tightening.
+
+4. Place sawhorses under a couple of elements (ideally two on each side) to keep the antenna from rolling
+
+5. Attach the phasing lines. The phasing lines go across the two driven elements, from the left side on the front element to the right on the rear, and vice-versa. There are 3D-printed spacers (de KK6ISP) which mostly keeps them from shorting to each other. The bolts are 3/8".
+
+IMPORTANT: The phasing straps connect to the outside set of bolts on each driven element, not the inside (TODO: Photo).
+
+IMPORTANT: Make sure the phasings straps are not shorting (touching) anything other than the bolts they are connected to. Tape them in place.
+
+6. Attach the Balun. The Balun has a set of U-Bolts for mounting. It should point with the coax facing towards the mast. The balun wires have ring terminals which connect to the outside set of bolts on the matching element of the forward driven eleent. These bolts are 3/8".
+
+7. Attach, or reposition the truss clamps. These each have one 7/16" bolt, and there are paint marks for where they should go.
+
+8. Attach the mast to the mast mounting plate. There are a set of U-bolts (either 3/8" or 7/16" TODO to check this) that attach the mast to the mounting plate. It should be mounted high enough (that is, enough above the antenna boom) to allow the truss to be taut, but not so high that it's too tight. Tighten the truss onto the mast before tigheting the mast onto the boom.
+
+9. Loosen the bolts attaching the mounting plate to the boom so that it can rotate not quite freely. This will make it easier to catch the mount when it's time. (only applicable if mounting in a way that requires rotation such as the tower trailer)
+
+10. Level the elements. Choose one (usually the front) to act as the reference, and, keeping one level on the reference, use a second level to check that all the elements are level to each other.
+
 
 ## Mounting
 
-Add mast, rotator, tower, feedline, and strain-relief steps here.
+For instructions on preparing a tower to accept an antenna, see one of the tower setup guides.
 
-## Testing
+If you want to mount the KT36A directly to a mast on a tower, you should skip step 8, and refer to the KT34 mounting instructions. 
 
-Add continuity, SWR, rotator, and on-air test steps here.
+If you are mounting the KT36A using its mast (such as to a tower with an adapter or with a through-hole mounting system), skip step 9 above. Place the bottom of the mast into the hole that can accept it and tighten down. This how we typically mount the KT36A to the AB621.
+
+IMPORTANT: If you are going to rotate the antenna as part of hoisting, make sure the mast plate is loosened so it doesn't stay sideways.
+
+Tie a string to one element on each side of the boom, to keep the antenna parallel to the ground while hoisting until the bolts are tightened, if you will rotate the antenna.
+
+Before hoisting the antenna, make sure the coax is connected. Tape the coax to the boom to reduce stress on it and keep it from bouncing around and interfering with anything.
 
 ## Teardown
 
-Add the teardown order, packing notes, and post-event inspection steps here.
+Teardown is essentially the reverse of assembly.
+
+1. First, follow any tower-specific lowering instructions. This will be a bit different for different kinds of towers. In any case, remove the feedline before taking the antenna off of the tower
+
+2. Place the antenna on a set of sawhorses. Put at least one sawhorse under an element on each side of the antenna to keep it from rolling.
+
+3. Remove the truss, balun, and phasing straps before pulling elements or hardware apart.
+
+4. Remove the mast by loosening the U-bolts and pulling it through.
+
+5. Remove elements by loosening hose clamps. The hose clamps on the two elements on the end do not need to be fully opened. The four middle elements do.
+
+6. Break the boom in half by removing the bolts. Put the bolts back in their holes so they don't get lost.
+
+
+7. Tape the two boom pieces together. Tape the mast to the two boom pieces. Tape the phasing straps and mounting plate to the boom pieces, as well as the truss rope.
+
 
 ## Common Gotchas and FAQs
 

--- a/events/setup-guides/equipment/klm-kt36.md
+++ b/events/setup-guides/equipment/klm-kt36.md
@@ -30,7 +30,16 @@ There are several markings on the antenna which tell us how to disassemble/reass
 
 ## Unpacking
 
-Add the parts inventory, inspection steps, required tools, crew size, and safety checks here.
+The antenna is usually stored on the roof of the PAARA box trailer. It's stored as:
+
+- 6 elements (color coded)
+- Boom bundle:
+	- 2 halves of the boom
+	- Mast
+	- Truss cable
+	- Mast mounting plate
+
+The "boom bundle" is taped together with electrical tape.
 
 ## Assembly
 

--- a/events/setup-guides/equipment/klm-kt36.md
+++ b/events/setup-guides/equipment/klm-kt36.md
@@ -4,6 +4,12 @@ This guide documents setup and teardown for the club's 6-element KLM KT-36 HF ya
 
 The KT-36 is an interesting antenna: a multi-band HF Yagi with 9-10 dB of gain across the three bands. It has served us well at field day.
 
+---
+**Table of Contents**
+* Table of Contents
+{:toc}
+---
+
 ## Overview
 
 This page covers how to put together our club's KLM KT36. It is specific to our club, in that we have a set of markings on the antenna that help us repeat the process.
@@ -116,4 +122,3 @@ Teardown is essentially the reverse of assembly.
 - The Balun mounts near the driven element which has the extra cross-component. The Balun leads mount to the bolts on the cross-compoonent. This is the rear driven element. Photo:
 - The phasing lines mount to the outside set of bolts on the two driven elements.
 - When you rotate the mast ahead of mounting, rotate it so that the truss stays above the elements, and the end of the mast which will go into the tower is slightly below the elements. This is to the left, facing towards the front of the antenna.
-

--- a/events/setup-guides/events/field-day.md
+++ b/events/setup-guides/events/field-day.md
@@ -13,6 +13,7 @@ Add the Field Day station lineup here.
 ## Equipment Guides
 
 * [KLM KT36 yagi antenna](/events/setup-guides/equipment/klm-kt36.html)
+* [KLM KT34A yagi antenna](/events/setup-guides/equipment/klm-kt34.html)
 
 ## Setup Notes
 

--- a/events/setup-guides/events/field-day.md
+++ b/events/setup-guides/events/field-day.md
@@ -1,0 +1,23 @@
+# Field Day Setup Guide
+
+This guide documents the setup and teardown plan for PAARA's Field Day station.
+
+## Overview
+
+Field Day setup uses multiple stations, towers, antennas, shelters, power distribution, logging computers, and food/social areas. The event guide should capture the site layout, operating station plan, setup schedule, safety constraints, volunteer roles, and teardown process.
+
+## Station Plan
+
+Add the Field Day station lineup here.
+
+## Equipment Guides
+
+* [KLM KT36 yagi antenna](/events/setup-guides/equipment/klm-kt36.html)
+
+## Setup Notes
+
+Add Field Day-specific setup notes here.
+
+## Teardown Notes
+
+Add Field Day-specific teardown notes here.

--- a/events/setup-guides/events/field-day.md
+++ b/events/setup-guides/events/field-day.md
@@ -2,6 +2,12 @@
 
 This guide documents the setup and teardown plan for PAARA's Field Day station.
 
+---
+**Table of Contents**
+* Table of Contents
+{:toc}
+---
+
 ## Overview
 
 Field Day setup uses multiple stations, towers, antennas, shelters, power distribution, logging computers, and food/social areas. The event guide should capture the site layout, operating station plan, setup schedule, safety constraints, volunteer roles, and teardown process.

--- a/events/setup-guides/events/index.md
+++ b/events/setup-guides/events/index.md
@@ -1,0 +1,12 @@
+# Event Setup Guides
+
+These guides cover whole-event setup plans. Each page should describe the event layout, station lineup, setup schedule, teardown plan, and the equipment guides needed by the crew.
+
+## Guides
+
+* [Pacificon](/events/setup-guides/events/pacificon.html)
+* [Field Day](/events/setup-guides/events/field-day.html)
+
+## Related Equipment Guides
+
+* [KLM KT36 yagi antenna](/events/setup-guides/equipment/klm-kt36.html)

--- a/events/setup-guides/events/index.md
+++ b/events/setup-guides/events/index.md
@@ -10,3 +10,4 @@ These guides cover whole-event setup plans. Each page should describe the event 
 ## Related Equipment Guides
 
 * [KLM KT36 yagi antenna](/events/setup-guides/equipment/klm-kt36.html)
+* [KLM KT34A yagi antenna](/events/setup-guides/equipment/klm-kt34.html)

--- a/events/setup-guides/events/index.md
+++ b/events/setup-guides/events/index.md
@@ -2,6 +2,12 @@
 
 These guides cover whole-event setup plans. Each page should describe the event layout, station lineup, setup schedule, teardown plan, and the equipment guides needed by the crew.
 
+---
+**Table of Contents**
+* Table of Contents
+{:toc}
+---
+
 ## Guides
 
 * [Pacificon](/events/setup-guides/events/pacificon.html)

--- a/events/setup-guides/events/pacificon.md
+++ b/events/setup-guides/events/pacificon.md
@@ -2,6 +2,12 @@
 
 This guide documents the setup and teardown plan for PAARA's Pacificon Special Event Station.
 
+---
+**Table of Contents**
+* Table of Contents
+{:toc}
+---
+
 ## Overview
 
 Pacificon setup uses PAARA's station equipment to support the W1AW/6 Special Event Station. The event guide should capture the site layout, operating station plan, antennas, power, network/logging setup, volunteer roles, and teardown process.

--- a/events/setup-guides/events/pacificon.md
+++ b/events/setup-guides/events/pacificon.md
@@ -1,0 +1,23 @@
+# Pacificon Setup Guide
+
+This guide documents the setup and teardown plan for PAARA's Pacificon Special Event Station.
+
+## Overview
+
+Pacificon setup uses PAARA's station equipment to support the W1AW/6 Special Event Station. The event guide should capture the site layout, operating station plan, antennas, power, network/logging setup, volunteer roles, and teardown process.
+
+## Station Plan
+
+Add the Pacificon band/station lineup here.
+
+## Equipment Guides
+
+* [KLM KT36 yagi antenna](/events/setup-guides/equipment/klm-kt36.html)
+
+## Setup Notes
+
+Add Pacificon-specific setup notes here.
+
+## Teardown Notes
+
+Add Pacificon-specific teardown notes here.

--- a/events/setup-guides/index.md
+++ b/events/setup-guides/index.md
@@ -1,0 +1,25 @@
+# Setup Guides
+
+These guides document how PAARA sets up and tears down the stations, antennas, towers, trailers, and support equipment used for club operating events.
+
+The goal is for each guide to be detailed enough that a prepared setup crew can use it without needing separate notes. Every event is a little different, so these pages should be updated whenever the station plan, site layout, or equipment configuration changes.
+
+## Event Setup Guides
+
+Event setup guides describe the full event layout and link to the equipment guides needed for each station.
+
+* [Pacificon](/events/setup-guides/events/pacificon.html)
+* [Field Day](/events/setup-guides/events/field-day.html)
+
+## Equipment Setup Guides
+
+Equipment setup guides describe reusable setup steps for individual pieces of club equipment. Event guides should link to these pages instead of duplicating equipment-specific instructions.
+
+* [KLM KT36 yagi antenna](/events/setup-guides/equipment/klm-kt36.html)
+
+## Planned Equipment Guides
+
+* AB-621 tower
+* 4-element KLM KT-34 yagi antenna
+* Tower trailer
+* 40 m monoband 4-element yagi

--- a/events/setup-guides/index.md
+++ b/events/setup-guides/index.md
@@ -16,10 +16,10 @@ Event setup guides describe the full event layout and link to the equipment guid
 Equipment setup guides describe reusable setup steps for individual pieces of club equipment. Event guides should link to these pages instead of duplicating equipment-specific instructions.
 
 * [KLM KT36 yagi antenna](/events/setup-guides/equipment/klm-kt36.html)
+* [KLM KT34A yagi antenna](/events/setup-guides/equipment/klm-kt34.html)
 
 ## Planned Equipment Guides
 
 * AB-621 tower
-* 4-element KLM KT-34 yagi antenna
 * Tower trailer
 * 40 m monoband 4-element yagi

--- a/events/setup-guides/index.md
+++ b/events/setup-guides/index.md
@@ -4,6 +4,12 @@ These guides document how PAARA sets up and tears down the stations, antennas, t
 
 The goal is for each guide to be detailed enough that a prepared setup crew can use it without needing separate notes. Every event is a little different, so these pages should be updated whenever the station plan, site layout, or equipment configuration changes.
 
+---
+**Table of Contents**
+* Table of Contents
+{:toc}
+---
+
 ## Event Setup Guides
 
 Event setup guides describe the full event layout and link to the equipment guides needed for each station.


### PR DESCRIPTION
Adds the setup guide structure for event and equipment guides.

Included guide pages:
- Pacificon setup guide
- Field Day setup guide
- KLM KT36 equipment setup guide

Also adds the preview Pages workflow that was present in the working tree for this branch.

Newsletter automation has been removed from this PR.