### PR TITLE
Add dark mode

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -6,4 +6,18 @@
 <!-- You can set your favicon here -->
 <!-- link rel="shortcut icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}" -->
 
+<!-- Dark mode (light is the default): apply a stored preference before paint
+     to prevent a flash. -->
+<script>
+  (function () {
+    try {
+      if (localStorage.getItem("paara-theme") === "dark") {
+        document.documentElement.setAttribute("data-theme", "dark");
+      }
+    } catch (e) {}
+  })();
+</script>
+<link rel="stylesheet" href="{{ '/assets/css/dark.css' | relative_url }}" type="text/css">
+<script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
+
 <!-- end custom head snippets -->

--- a/assets/css/dark.css
+++ b/assets/css/dark.css
@@ -1,0 +1,153 @@
+/* Dark mode overrides. Light is the default; these rules apply only when
+   data-theme="dark" is set on <html> (see theme-toggle.js). */
+
+/* TOGGLE BUTTON */
+
+.theme-toggle {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  color: #fff;
+  cursor: pointer;
+  background: rgba(13, 27, 42, 0.35);
+  border: solid 1px rgba(255, 255, 255, 0.55);
+  border-radius: 50%;
+  appearance: none;
+  -webkit-appearance: none;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+.theme-toggle:hover {
+  background: rgba(13, 27, 42, 0.6);
+  transform: scale(1.06);
+}
+.theme-toggle:focus-visible {
+  outline: solid 2px #9ddcff;
+  outline-offset: 2px;
+}
+.theme-toggle svg {
+  display: block;
+  width: 22px;
+  height: 22px;
+  fill: currentColor;
+}
+
+/* Moon shows in light mode; sun shows in dark mode. */
+.theme-toggle .icon-sun {
+  display: none;
+}
+.theme-toggle .icon-moon {
+  display: block;
+}
+html[data-theme="dark"] .theme-toggle .icon-sun {
+  display: block;
+}
+html[data-theme="dark"] .theme-toggle .icon-moon {
+  display: none;
+}
+html[data-theme="dark"] .theme-toggle {
+  color: #ffd45e;
+  background: rgba(230, 233, 238, 0.12);
+  border-color: rgba(230, 233, 238, 0.5);
+}
+html[data-theme="dark"] .theme-toggle:hover {
+  background: rgba(230, 233, 238, 0.22);
+}
+
+/* LAYOUT STYLES */
+
+html[data-theme="dark"] body {
+  color: #c7cbd1;
+  background: #14171c;
+  background-image: none;
+}
+
+html[data-theme="dark"] a {
+  color: #6cb0f0;
+}
+html[data-theme="dark"] a:hover {
+  color: #8cc4f7;
+}
+
+html[data-theme="dark"] header {
+  background: #0d1b2a;
+  background-image: none;
+  border-bottom-color: #1d2b3a;
+}
+
+html[data-theme="dark"] #content-wrapper {
+  border-top-color: #2d333b;
+}
+
+html[data-theme="dark"] aside#sidebar {
+  background-image: none;
+}
+
+/* The base theme forces the current nav item to black; restore it for dark. */
+html[data-theme="dark"] .sidebar.current {
+  color: #fff;
+  text-decoration-color: #fff;
+}
+
+html[data-theme="dark"] code,
+html[data-theme="dark"] pre {
+  color: #c7cbd1;
+}
+html[data-theme="dark"] code {
+  background-color: #1c2128;
+  border-color: #2d333b;
+}
+html[data-theme="dark"] pre {
+  background: #1c2128;
+  border-color: #2d333b;
+}
+html[data-theme="dark"] pre code {
+  color: #c7cbd1;
+  background-color: transparent;
+}
+
+/* COMMON STYLES */
+
+html[data-theme="dark"] hr {
+  border-top-color: #2d333b;
+}
+
+html[data-theme="dark"] table,
+html[data-theme="dark"] td {
+  border-color: #2d333b;
+}
+
+html[data-theme="dark"] form {
+  background: #1c2128;
+}
+
+/* GENERAL ELEMENT TYPE STYLES */
+
+html[data-theme="dark"] #main-content h1,
+html[data-theme="dark"] #main-content h2,
+html[data-theme="dark"] #main-content h3,
+html[data-theme="dark"] #main-content h4,
+html[data-theme="dark"] #main-content h5,
+html[data-theme="dark"] #main-content h6 {
+  color: #e6e9ee;
+}
+
+html[data-theme="dark"] blockquote {
+  border-left-color: #3a4250;
+}
+
+html[data-theme="dark"] footer {
+  color: #8b919a;
+}
+html[data-theme="dark"] footer a {
+  color: #aab1bb;
+}
+html[data-theme="dark"] footer a:hover {
+  color: #cfd4db;
+}

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,70 @@
+/*
+ * Sun/moon dark-mode toggle. Light is the default; a stored preference is
+ * applied before paint by an inline script in head-custom.html to prevent a
+ * flash. This file builds the toggle button and remembers the choice.
+ */
+(function () {
+  "use strict";
+
+  var STORAGE_KEY = "paara-theme";
+
+  function currentTheme() {
+    return document.documentElement.getAttribute("data-theme") === "dark"
+      ? "dark"
+      : "light";
+  }
+
+  function applyTheme(theme) {
+    if (theme === "dark") {
+      document.documentElement.setAttribute("data-theme", "dark");
+    } else {
+      document.documentElement.removeAttribute("data-theme");
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch (e) {
+      /* localStorage may be unavailable */
+    }
+    var btn = document.querySelector(".theme-toggle");
+    if (btn) {
+      btn.setAttribute("aria-pressed", theme === "dark" ? "true" : "false");
+    }
+  }
+
+  function buildButton() {
+    var btn = document.createElement("button");
+    btn.className = "theme-toggle";
+    btn.type = "button";
+    btn.setAttribute("aria-label", "Toggle dark mode");
+    btn.setAttribute("aria-pressed", currentTheme() === "dark" ? "true" : "false");
+    btn.title = "Toggle light / dark mode";
+
+    // Moon shows in light mode (click to go dark); sun shows in dark mode.
+    var moon =
+      '<svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true">' +
+      '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>';
+
+    var sun =
+      '<svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true">' +
+      '<path d="M12 17a5 5 0 1 1 0-10 5 5 0 0 1 0 10zm0-13a1 1 0 0 1 1 1v1.5a1 1 0 1 1-2 0V5a1 1 0 0 1 1-1zm0 13.5a1 1 0 0 1 1 1V20a1 1 0 1 1-2 0v-1.5a1 1 0 0 1 1-1zM4 12a1 1 0 0 1 1-1h1.5a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1zm13.5 0a1 1 0 0 1 1-1H20a1 1 0 1 1 0 2h-1.5a1 1 0 0 1-1-1zM6.3 6.3a1 1 0 0 1 1.4 0l1.1 1.1a1 1 0 1 1-1.4 1.4L6.3 7.7a1 1 0 0 1 0-1.4zm9 9a1 1 0 0 1 1.4 0l1.1 1.1a1 1 0 0 1-1.4 1.4l-1.1-1.1a1 1 0 0 1 0-1.4zm2.5-9a1 1 0 0 1 0 1.4l-1.1 1.1a1 1 0 1 1-1.4-1.4l1.1-1.1a1 1 0 0 1 1.4 0zm-9 9a1 1 0 0 1 0 1.4l-1.1 1.1a1 1 0 0 1-1.4-1.4l1.1-1.1a1 1 0 0 1 1.4 0z"/></svg>';
+
+    btn.innerHTML = moon + sun;
+    btn.addEventListener("click", function () {
+      applyTheme(currentTheme() === "dark" ? "light" : "dark");
+    });
+    return btn;
+  }
+
+  function init() {
+    if (document.querySelector(".theme-toggle")) {
+      return;
+    }
+    document.body.appendChild(buildButton());
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
Add a dark mode to paara.org for accessibility and user comfort.

Light mode remains the default, sun/moon toggle button swaps between them, and settings are remembered between visits. Stored preference is applied before load to avoid the single-frame full screen white flashbang that happens to dark mode users with naive implementations.

This PR was produced with significant AI assistance but was tested extensively before submission.